### PR TITLE
fix rubygems proxy fails with 404 but install works

### DIFF
--- a/lib/geminabox/proxy/hostess.rb
+++ b/lib/geminabox/proxy/hostess.rb
@@ -59,7 +59,7 @@ module Geminabox
         file = File.expand_path(File.join(Server.data, *request.path_info))
 
         unless File.exists?(file)
-          ruby_gems_url = 'http://production.cf.rubygems.org'
+          ruby_gems_url = 'https://rubygems.org'
           path = File.join(ruby_gems_url, *request.path_info)
           content = Geminabox.http_adapter.get_content(path)
           GemStore.create(IncomingGem.new(StringIO.new(content)))

--- a/lib/geminabox/version.rb
+++ b/lib/geminabox/version.rb
@@ -1,3 +1,3 @@
 module Geminabox
-  VERSION = '0.12.4' unless defined? VERSION
+  VERSION = '0.12.4-tumblr' unless defined? VERSION
 end


### PR DESCRIPTION
fix url so proxy can talk to ruby gems.org.
